### PR TITLE
fix include parse

### DIFF
--- a/lsp/codejump/definition.go
+++ b/lsp/codejump/definition.go
@@ -3,7 +3,6 @@ package codejump
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/joyme123/thrift-ls/lsp/cache"
 	"github.com/joyme123/thrift-ls/lsp/lsputils"
@@ -61,11 +60,9 @@ func serviceDefinition(ctx context.Context, ss *cache.Snapshot, file uri.URI, as
 func ServiceDefinitionIdentifier(ctx context.Context, ss *cache.Snapshot, file uri.URI, ast *parser.Document, targetNode parser.Node) (uri.URI, *parser.Identifier, string, error) {
 	identifierName := targetNode.(*parser.IdentifierName)
 
-	include, identifier, found := strings.Cut(identifierName.Text, ".")
+	include, identifier := lsputils.ParseIdent(file, ast.Includes, identifierName.Text)
 	var astFile uri.URI
-	if !found {
-		identifier = include
-		include = ""
+	if include == "" {
 		astFile = file
 	} else {
 		path := lsputils.GetIncludePath(ast, include)
@@ -113,11 +110,9 @@ func TypeNameDefinitionIdentifier(ctx context.Context, ss *cache.Snapshot, file 
 		return "", nil, "", nil
 	}
 
-	include, identifier, found := strings.Cut(typeV, ".")
+	include, identifier := lsputils.ParseIdent(file, ast.Includes, typeV)
 	var astFile uri.URI
-	if !found {
-		identifier = include
-		include = ""
+	if include == "" {
 		astFile = file
 	} else {
 		path := lsputils.GetIncludePath(ast, include)
@@ -183,11 +178,9 @@ func ConstValueTypeDefinitionIdentifier(ctx context.Context, ss *cache.Snapshot,
 		return "", nil, nil
 	}
 
-	include, identifier, found := strings.Cut(constValue.Value.(string), ".")
+	include, identifier := lsputils.ParseIdent(file, ast.Includes, constValue.Value.(string))
 	var astFile uri.URI
-	if !found {
-		identifier = include
-		include = ""
+	if include == "" {
 		astFile = file
 	} else {
 		path := lsputils.GetIncludePath(ast, include)

--- a/lsp/codejump/definition_test.go
+++ b/lsp/codejump/definition_test.go
@@ -46,6 +46,17 @@ service Demo {
   list<user.UserType> UserTypes(1:user.Test3 arg1=user.Test3.TWO, 2:string arg2=user.DefaultName)
 }`
 
+	// user.extra.thrift
+	file3 := `struct Test {}`
+
+	file4 := `include "user.extra.thrift"
+include "user.thrift"
+
+struct Person {
+  1: required user.extra.Test field1,
+  2: required user.Test field2,
+}`
+
 	ss := cache.BuildSnapshotForTest([]*cache.FileChange{
 		{
 			URI:     "file:///tmp/user.thrift",
@@ -57,6 +68,18 @@ service Demo {
 			URI:     "file:///tmp/api.thrift",
 			Version: 0,
 			Content: []byte(file2),
+			From:    cache.FileChangeTypeDidOpen,
+		},
+		{
+			URI:     "file:///tmp/user.extra.thrift",
+			Version: 0,
+			Content: []byte(file3),
+			From:    cache.FileChangeTypeDidOpen,
+		},
+		{
+			URI:     "file:///tmp/app.thrift",
+			Version: 0,
+			Content: []byte(file4),
 			From:    cache.FileChangeTypeDidOpen,
 		},
 	})
@@ -263,6 +286,62 @@ service Demo {
 						End: protocol.Position{
 							Line:      27,
 							Character: 24,
+						},
+					},
+				},
+			},
+			assertion: assert.NoError,
+		},
+		{
+			name: "case include 1",
+			args: args{
+				ctx:  context.TODO(),
+				ss:   ss,
+				file: "file:///tmp/app.thrift",
+				pos: protocol.Position{
+					Line:      4,
+					Character: 25,
+				},
+			},
+			want: []protocol.Location{
+				{
+					URI: "file:///tmp/user.extra.thrift",
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 7,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 11,
+						},
+					},
+				},
+			},
+			assertion: assert.NoError,
+		},
+		{
+			name: "case include 2",
+			args: args{
+				ctx:  context.TODO(),
+				ss:   ss,
+				file: "file:///tmp/app.thrift",
+				pos: protocol.Position{
+					Line:      5,
+					Character: 19,
+				},
+			},
+			want: []protocol.Location{
+				{
+					URI: "file:///tmp/user.thrift",
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 7,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 11,
 						},
 					},
 				},

--- a/lsp/codejump/hover.go
+++ b/lsp/codejump/hover.go
@@ -3,7 +3,6 @@ package codejump
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/joyme123/thrift-ls/format"
 	"github.com/joyme123/thrift-ls/lsp/cache"
@@ -50,11 +49,9 @@ func Hover(ctx context.Context, ss *cache.Snapshot, file uri.URI, pos protocol.P
 func hoverService(ctx context.Context, ss *cache.Snapshot, file uri.URI, ast *parser.Document, targetNode parser.Node) (string, error) {
 	identifierName := targetNode.(*parser.IdentifierName)
 	name := identifierName.Text
-	include, identifier, found := strings.Cut(name, ".")
+	include, identifier := lsputils.ParseIdent(file, ast.Includes, name)
 	var astFile uri.URI
-	if !found {
-		identifier = include
-		include = ""
+	if include == "" {
 		astFile = file
 	} else {
 		path := lsputils.GetIncludePath(ast, include)
@@ -89,11 +86,9 @@ func hoverDefinition(ctx context.Context, ss *cache.Snapshot, file uri.URI, ast 
 		return "", nil
 	}
 
-	include, identifier, found := strings.Cut(typeV, ".")
+	include, identifier := lsputils.ParseIdent(file, ast.Includes, typeV)
 	var astFile uri.URI
-	if !found {
-		identifier = include
-		include = ""
+	if include == "" {
 		astFile = file
 	} else {
 		path := lsputils.GetIncludePath(ast, include)
@@ -144,11 +139,9 @@ func hoverConstValue(ctx context.Context, ss *cache.Snapshot, file uri.URI, ast 
 		return "", nil
 	}
 
-	include, identifier, found := strings.Cut(constValue.Value.(string), ".")
+	include, identifier := lsputils.ParseIdent(file, ast.Includes, constValue.Value.(string))
 	var astFile uri.URI
-	if !found {
-		identifier = include
-		include = ""
+	if include == "" {
 		astFile = file
 	} else {
 		path := lsputils.GetIncludePath(ast, include)

--- a/lsp/codejump/reference.go
+++ b/lsp/codejump/reference.go
@@ -68,7 +68,7 @@ func Reference(ctx context.Context, ss *cache.Snapshot, file uri.URI, pos protoc
 			if !strings.Contains(svcName, ".") {
 				svcName = fmt.Sprintf("%s.%s", lsputils.GetIncludeName(file), svcName)
 			} else {
-				include, _, _ := strings.Cut(svcName, ".")
+				include, _ := lsputils.ParseIdent(file, pf.AST().Includes, svcName)
 				path := lsputils.GetIncludePath(pf.AST(), include)
 				if path != "" { // doesn't match any include path
 					file = lsputils.IncludeURI(file, path)

--- a/lsp/codejump/rename.go
+++ b/lsp/codejump/rename.go
@@ -95,7 +95,7 @@ func Rename(ctx context.Context, ss *cache.Snapshot, file uri.URI, pos protocol.
 			if !strings.Contains(svcName, ".") {
 				svcName = fmt.Sprintf("%s.%s", lsputils.GetIncludeName(file), svcName)
 			} else {
-				include, _, _ := strings.Cut(svcName, ".")
+				include, _ := lsputils.ParseIdent(file, pf.AST().Includes, svcName)
 				path := lsputils.GetIncludePath(pf.AST(), include)
 				if path != "" { // doesn't match any include path
 					file = lsputils.IncludeURI(file, path)

--- a/lsp/lsputils/utils.go
+++ b/lsp/lsputils/utils.go
@@ -2,6 +2,7 @@ package lsputils
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/joyme123/thrift-ls/parser"
@@ -43,15 +44,15 @@ func GetIncludeName(file uri.URI) string {
 // if doesn't match, return empty string
 func GetIncludePath(ast *parser.Document, includeName string) string {
 	for _, include := range ast.Includes {
-		if include.BadNode || include.Path == nil || include.Path.BadNode {
+		if include.BadNode || include.Path == nil || include.Path.BadNode || include.Path.Value == nil {
 			continue
 		}
 		items := strings.Split(include.Path.Value.Text, "/")
 		path := items[len(items)-1]
-		name, _, found := strings.Cut(path, ".")
-		if !found {
+		if !strings.HasSuffix(path, ".thrift") {
 			continue
 		}
+		name := strings.TrimSuffix(path, ".thrift")
 		if name == includeName {
 			return include.Path.Value.Text
 		}
@@ -70,4 +71,45 @@ func IncludeURI(cur uri.URI, includePath string) uri.URI {
 	path := filepath.Join(basePath, includePath)
 
 	return uri.File(path)
+}
+
+// ParseIdent parse an identifier. identifier format:
+//  1. identifier
+//  2. include.identifier
+//
+// it returns include, ident
+func ParseIdent(cur uri.URI, includes []*parser.Include, identifier string) (include, ident string) {
+	includeNames := IncludeNames(cur, includes)
+	// parse include from includeNames
+
+	sort.SliceStable(includeNames, func(i, j int) bool {
+		// sort by string length, make sure longest include match early
+		// examples:
+		// user.extra
+		// user
+		return len(includeNames[i]) > len(includeNames[j])
+	})
+
+	for _, incName := range includeNames {
+		prefix := incName + "."
+		if strings.HasPrefix(identifier, prefix) {
+			return incName, strings.TrimPrefix(identifier, prefix)
+		}
+	}
+
+	return "", identifier
+}
+
+// IncludeNames returns include names from include ast nodes
+func IncludeNames(cur uri.URI, includes []*parser.Include) (includeNames []string) {
+	for _, inc := range includes {
+		if inc.Path != nil && inc.Path.Value != nil {
+			path := inc.Path.Value.Text
+			u := IncludeURI(cur, path)
+			includeName := GetIncludeName(u)
+			includeNames = append(includeNames, includeName)
+		}
+	}
+
+	return includeNames
 }


### PR DESCRIPTION
issues:  User.Base.Name 错误解析成 User + Base.Name，期望是 User.Base + Name

solution: 根据 include 的文件来解析。

1. 如果 include 了 User.Base.thrift，则解析成 User.Base + Name
2. 如果只 include 了 User.thrift，则解析成 User + Base.Name 